### PR TITLE
refs #7 Use simplecov for code coverage measurement tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@
 /spec/reports/
 /tmp/
 
+coverage
 Gemfile.lock

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,8 +2,11 @@
 
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 
-require 'timetree'
+require 'simplecov'
+SimpleCov.start
 require 'minitest/autorun'
 require 'minitest/reporters'
 Minitest::Reporters.use!
 require 'webmock/minitest'
+
+require 'timetree'

--- a/timetree.gemspec
+++ b/timetree.gemspec
@@ -37,4 +37,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest-reporters', '~> 1.4.2'
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'webmock', '~> 3.7.6'
+  spec.add_development_dependency 'simplecov', '~> 0.18.5'
 end


### PR DESCRIPTION

```
$ bundle exec rake test
Started with run options --seed 23414

  14/14: [=====================================================================================================================================] 100% Time: 00:00:01, Time: 00:00:01

Finished in 1.01049s
14 tests, 478 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for Unit Tests to /Users/kenjikoshikawa/dev/github/koshilife/timetree/coverage. 318 / 328 LOC (96.95%) covered.
```

<img width="698" alt="result_of_code_coverage" src="https://user-images.githubusercontent.com/583336/85642951-cc475800-b6cd-11ea-8a18-6f426b9c28f2.png">
