### PR TITLE
release v0.1.6

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -21,6 +21,8 @@ jobs:
           gem install bundler
           bundle install --jobs 4 --retry 3
           bundle exec rake test
+        env:
+          CODECOV_TOKEN: ${{secrets.CODECOV_TOKEN}}
 
       - name: Publish to RubyGems
         run: |

--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Ruby 2.6
         uses: actions/setup-ruby@v1
         with:
-          version: 2.6.x
+          ruby-version: 2.6
 
       - name: Build and test
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,3 +17,5 @@ jobs:
           gem install bundler
           bundle install --jobs 4 --retry 3
           bundle exec rake test
+        env:
+          CODECOV_TOKEN: ${{secrets.CODECOV_TOKEN}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.1.6
+
+- refs #16 add code coverage to readme.
+- refs #17 update deprecated `version` for `ruby-version` on gem-push.yml.
+
 # 0.1.5
 
 - refs #6 setup GitHub Actions.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Simple TimeTree APIs client
 
 [![Test](https://github.com/koshilife/timetree-api-ruby-client/workflows/Test/badge.svg)](https://github.com/koshilife/timetree-api-ruby-client/actions?query=workflow%3ATest)
+[![codecov](https://codecov.io/gh/koshilife/tanita-api-ruby-client/branch/master/graph/badge.svg)](https://codecov.io/gh/koshilife/tanita-api-ruby-client)
 [![Gem Version](https://badge.fury.io/rb/timetree.svg)](http://badge.fury.io/rb/timetree)
+[![license](https://img.shields.io/github/license/koshilife/timetree-api-ruby-client)](https://github.com/koshilife/timetree-api-ruby-client/blob/master/LICENSE.txt)
 
 ## About
 

--- a/lib/timetree/version.rb
+++ b/lib/timetree/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module TimeTree
-  VERSION = '0.1.5'
+  VERSION = '0.1.6'
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,10 @@ $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 
 require 'simplecov'
 SimpleCov.start
+if ENV['CI'] == 'true'
+  require 'codecov'
+  SimpleCov.formatter = SimpleCov::Formatter::Codecov
+end
 require 'minitest/autorun'
 require 'minitest/reporters'
 Minitest::Reporters.use!

--- a/timetree.gemspec
+++ b/timetree.gemspec
@@ -33,9 +33,10 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'zeitwerk', '~> 2.3.0'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
+  spec.add_development_dependency 'codecov', '~> 0.1.17'
   spec.add_development_dependency 'minitest', '~> 5.14.0'
   spec.add_development_dependency 'minitest-reporters', '~> 1.4.2'
   spec.add_development_dependency 'rake', '~> 12.0'
-  spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'simplecov', '~> 0.18.5'
+  spec.add_development_dependency 'webmock', '~> 3.7.6'
 end


### PR DESCRIPTION
- refs #16 add code coverage to readme.
- refs #17 update deprecated `version` for `ruby-version` on gem-push.yml.
